### PR TITLE
root-node, plugins and only-plugins options added for aco customization

### DIFF
--- a/Console/Command/AclExtrasShell.php
+++ b/Console/Command/AclExtrasShell.php
@@ -96,6 +96,10 @@ class AclExtrasShell extends Shell {
  * @return void
  **/
 	function aco_update() {
+        if(!empty($this->params['root-node'])) {
+            $this->rootNode = $this->params['root-node'];
+        }
+
 		$root = $this->_checkNode($this->rootNode, $this->rootNode, null);
 		$controllers = $this->getControllerList();
 		$this->_updateControllers($root, $controllers);
@@ -241,11 +245,29 @@ class AclExtrasShell extends Shell {
 		return parent::getOptionParser()
 			->description(__("Better manage, and easily synchronize you application's ACO tree"))
 			->addSubcommand('aco_update', array(
-				'help' => __('Add new ACOs for new controllers and actions. Does not remove nodes from the ACO table.')
+				'help' => __('Add new ACOs for new controllers and actions. Does not remove nodes from the ACO table.'),
+				'parser' => array(
+					'options' => array(
+						'root-node' => array(
+                            'short' => 'r',
+							'help' => __('Enter custom root node.'),
+                            'default' => 'controllers',
+						)
+					)
+				)
 			))->addSubcommand('aco_sync', array(
 				'help' => __('Perform a full sync on the ACO table.' .
 					'Will create new ACOs or missing controllers and actions.' .
-					'Will also remove orphaned entries that no longer have a matching controller/action')
+					'Will also remove orphaned entries that no longer have a matching controller/action'),
+				'parser' => array(
+					'options' => array(
+						'root-node' => array(
+                            'short' => 'r',
+							'help' => __('Enter custom root node.'),
+                            'default' => 'controllers',
+						)
+					)
+				)
 			))->addSubcommand('verify', array(
 				'help' => __('Verify the tree structure of either your Aco or Aro Trees'),
 				'parser' => array(

--- a/Console/Command/AclExtrasShell.php
+++ b/Console/Command/AclExtrasShell.php
@@ -88,7 +88,7 @@ class AclExtrasShell extends Shell {
  **/
 	function aco_sync() {
 		$this->_clean = true;
-		$this->aco_update();
+		return $this->aco_update();
 	}
 /**
  * Updates the Aco Tree with new controller actions.

--- a/Console/Command/AclExtrasShell.php
+++ b/Console/Command/AclExtrasShell.php
@@ -100,8 +100,8 @@ class AclExtrasShell extends Shell {
             $this->rootNode = $this->params['root-node'];
         }
 
+        $root = $this->_checkNode($this->rootNode, $this->rootNode, null);
         if(empty($this->params['only-plugins'])) {
-            $root = $this->_checkNode($this->rootNode, $this->rootNode, null);
             $controllers = $this->getControllerList();
             $this->_updateControllers($root, $controllers);
         }

--- a/Controller/Component/AclExtrasComponent.php
+++ b/Controller/Component/AclExtrasComponent.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * AclExtrasComponent Class
+ *
+ * Saves permissions in Session   
+ * Inspired by http://www.mainelydesign.com/blog/view/getting-all-acl-permissions-in-one-lookup-cakephp-1-3
+ **/
+class AclExtrasComponent extends Component {
+    
+    var $components = array('Acl', 'Auth', 'Session');
+    var $options = array('model'=>'Aco', 'field'=>'alias');
+    
+    //used for recursive variable setting/checking
+    var $perms = array();   //for ACL defined permissions
+    var $permissionsArray = array();    //for all permissions
+    var $inheritPermission = array();   //array indexed by level to hold the inherited permission
+
+    public function create($controller, $options = array()) {
+        $this->options = array_merge($this->options, $options);
+        
+        //GET ACL PERMISSIONS
+        $group_id = $controller->Auth->user('user_group_id');
+        $acos = $controller->Acl->Aco->find('threaded');
+        $group_aro = $controller->Acl->Aro->find('threaded',array('conditions'=>array('Aro.foreign_key'=>$group_id, 'Aro.model'=>'UserGroup')));
+        $group_perms = Set::extract('{n}.Aco', $group_aro);
+        $pAco = array();
+        foreach($group_perms[0] as $value) {
+            $pAco[$value['id']] = $value;
+        }
+        $user_id = $controller->Auth->user('id');
+        $user_aro = $controller->Acl->Aro->find('threaded',array('conditions'=>array('Aro.foreign_key'=>$user_id, 'Aro.model'=>'User')));
+        $user_perms = Set::extract('{n}.Aco', $user_aro);
+        foreach($user_perms[0] as $value) {
+            $pAco[$value['id']] = $value;
+        }
+        
+        $this->perms = $pAco;
+        $this->_addPermissions($acos, $this->options['model'], $this->options['field'], 0, '');
+        
+        $controller->Session->write('Auth.Permissions', $this->permissionsArray);
+        return $this->permissionsArray;
+    }
+    
+    private function _addPermissions($acos, $modelName, $fieldName, $level, $alias) {
+ 
+        foreach ($acos as $key=>$val)
+        {
+            $thisAlias = $alias . $val[$modelName][$fieldName];
+             
+            if(isset($this->perms[$val[$modelName]['id']])) {
+                $curr_perm = $this->perms[$val[$modelName]['id']];
+                if($curr_perm['Permission']['_create'] == 1) {
+                    $this->permissionsArray[] = $thisAlias;
+                    $this->inheritPermission[$level] = 1;
+                } else {
+                    $this->inheritPermission[$level] = -1;
+                }
+            } else {
+                if(!empty($this->inheritPermission)) {
+                    //check for inheritedPermissions, by checking closest array element
+                    $revPerms = array_reverse($this->inheritPermission);             
+                    if($revPerms[0] == 1) {
+                        $this->permissionsArray[] = $thisAlias; //the level above was set to 1, so this should be a 1
+                    }
+                     
+                }
+            }
+ 
+            if(isset($val['children'][0])) {
+                $old_alias = $alias;
+                $alias .= $val[$modelName][$fieldName] .'/';
+                $this->_addPermissions($val['children'], $modelName, $fieldName, $level+1, $alias);
+                unset($this->inheritPermission[$level+1]);  //don't want the last level's inheritance, in case it was set
+                unset($this->inheritPermission[$level]);    //don't want this inheritance anymore, in case it was set
+                $alias = $old_alias;
+            }
+        }
+ 
+        return;
+    }
+}

--- a/View/Helper/AclExtrasHelper.php
+++ b/View/Helper/AclExtrasHelper.php
@@ -1,0 +1,50 @@
+<?php
+
+App::uses('AppHelper', 'View/Helper');
+
+class AclExtrasHelper extends AppHelper {
+	
+	public $helpers = array('Session');
+
+    public $rootNode = 'controllers';
+
+    function __construct(View $view, $settings = array()) {
+        parent::__construct($view, $settings);
+        extract($settings);
+        if(isset($rootNode)) {
+            $this->rootNode = $rootNode;
+        }
+    }
+	
+	function hasPermission($url) {
+		if (!is_array($url)) {
+			return false;
+		}
+		
+		extract($url);
+		
+		if(!isset($plugin)) {
+            $plugin = $this->request->plugin;
+		}
+        $plugin = Inflector::camelize($plugin);
+		
+		if (!isset($controller)) {
+			$controller = $this->request->controller;
+		}  
+		$controller = Inflector::camelize($controller);
+		
+		if (!isset($action)) {
+			$action = $this->request->action;
+		}
+		
+		if(isset($plugin) and !empty($plugin)) {
+			$controller = $plugin.'/'.$controller;
+		}
+		
+		$permission = $this->rootNode.'/'.$controller.'/'.$action;
+		
+		return in_array($permission, $this->Session->read('Auth.Permissions'));
+	
+	}
+	
+}


### PR DESCRIPTION
Sometimes you need to generate only specific acos and you still don't want to create acos one by one with acl shell. I added 3 options (root-node, plugins and only-plugins) which are used with AclExtras aco_sync and aco_update which allows you to generate only specific acos.

Example:

```
cake AclExtras.AclExtras aco_sync --root-node=admin --plugins=Admin,FrontpageAdmin,AssetAdmin
cake AclExtras.AclExtras aco_sync --root-node=frontend --plugins=Frontpage
```
