### PR TITLE
Remove abstract classes in order not to take in account.

### DIFF
--- a/Lib/AclExtras.php
+++ b/Lib/AclExtras.php
@@ -232,6 +232,9 @@ class AclExtras extends Object {
 	protected function _getCallbacks($className) {
 		$callbacks = array();
 		$reflection = new ReflectionClass($className);
+		if ($reflection->isAbstract()) {
+			return $callbacks;
+		}
 		try {
 			$method = $reflection->getMethod('implementedEvents');
 		} catch (ReflectionException $e) {


### PR DESCRIPTION
Before this little change, Abstract classes were included in the list of classes to add into acos. 
So when later it does:

``` php
$reflection->newInstanceWithoutConstructor()
```

it throws **Fatal Error Error: Cannot instantiate abstract class** when PHP version is >=5.4.
No error is thrown when PHP < v5.4, but it inserts Abtract class in acos table but never used, because it is odd to allow/deny permission in abtract classes.
