### PR TITLE
Use PSR-1 for PHPUnit TestSuite

### DIFF
--- a/Test/Case/AllTestsTest.php
+++ b/Test/Case/AllTestsTest.php
@@ -1,8 +1,11 @@
 <?php
+
+use PHPUnit\Framework\TestSuite;
+
 /**
  * All Tests Test case.
  */
-class AllTestsTest extends PHPUnit_Framework_TestSuite {
+class AllTestsTest extends TestSuite {
 
 /**
  * suite method, defines tests for this suite.


### PR DESCRIPTION
Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestSuite class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).